### PR TITLE
[feat] Enum 검증 @enumValid 추가 및 상품 신고 API

### DIFF
--- a/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
+++ b/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
@@ -2,8 +2,9 @@ package com.psr.psr.global.entity
 
 import com.psr.psr.global.exception.BaseException
 import com.psr.psr.global.exception.BaseResponseCode
+import com.psr.psr.global.resolver.EnumType
 
-enum class ReportCategory(val value: String) {
+enum class ReportCategory(override val value: String) : EnumType {
     JUNK("스팸홍보/도배"),
     ABUSE("욕설/혐오/차별"),
     PORN("음란물/유해한 정보"),
@@ -15,5 +16,6 @@ enum class ReportCategory(val value: String) {
             return ReportCategory.values().find { it.name == name }
                 ?: throw BaseException(BaseResponseCode.INVALID_REPORT_CATEGORY)
         }
+        
     }
 }

--- a/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
+++ b/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
@@ -18,7 +18,7 @@ enum class ReportCategory(override val value: String) : EnumType {
         }
 
         fun findByValue(value: String): ReportCategory {
-            return ReportCategory.values().find { it.value == value }
+            return ReportCategory.values().find { it.value == value }!!
         }
     }
 }

--- a/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
+++ b/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
@@ -16,6 +16,10 @@ enum class ReportCategory(override val value: String) : EnumType {
             return ReportCategory.values().find { it.name == name }
                 ?: throw BaseException(BaseResponseCode.INVALID_REPORT_CATEGORY)
         }
-        
+
+        fun findByValue(value: String): ReportCategory {
+            return ReportCategory.values().find { it.value == value }
+                ?: throw BaseException(BaseResponseCode.INVALID_REPORT_CATEGORY)
+        }
     }
 }

--- a/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
+++ b/src/main/kotlin/com/psr/psr/global/entity/ReportCategory.kt
@@ -19,7 +19,6 @@ enum class ReportCategory(override val value: String) : EnumType {
 
         fun findByValue(value: String): ReportCategory {
             return ReportCategory.values().find { it.value == value }
-                ?: throw BaseException(BaseResponseCode.INVALID_REPORT_CATEGORY)
         }
     }
 }

--- a/src/main/kotlin/com/psr/psr/global/resolver/EnumType.kt
+++ b/src/main/kotlin/com/psr/psr/global/resolver/EnumType.kt
@@ -1,0 +1,5 @@
+package com.psr.psr.global.resolver
+
+interface EnumType {
+    val value: String
+}

--- a/src/main/kotlin/com/psr/psr/global/resolver/EnumValid.kt
+++ b/src/main/kotlin/com/psr/psr/global/resolver/EnumValid.kt
@@ -1,0 +1,16 @@
+package com.psr.psr.global.resolver
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Constraint(validatedBy = [EnumValidator::class])
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EnumValid(
+    val enumClass: KClass<out EnumType>,
+    val message: String = "올바르지 않은 값입니다",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)
+

--- a/src/main/kotlin/com/psr/psr/global/resolver/EnumValidator.kt
+++ b/src/main/kotlin/com/psr/psr/global/resolver/EnumValidator.kt
@@ -1,0 +1,25 @@
+package com.psr.psr.global.resolver
+
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+
+class EnumValidator : ConstraintValidator<EnumValid, String> {
+    private lateinit var annotation: EnumValid
+
+    override fun initialize(constraintAnnotation: EnumValid) {
+        this.annotation = constraintAnnotation
+    }
+
+    override fun isValid(value: String?, context: ConstraintValidatorContext?): Boolean {
+        val enumConstants = this.annotation.enumClass.java.enumConstants
+        if (enumConstants.isNotEmpty()) {
+            val enumValues: List<EnumValue> = enumConstants.map { EnumValue(it) }.toList()
+            for (enumValue in enumValues) {
+                if (value.equals(enumValue.value)) return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/kotlin/com/psr/psr/global/resolver/EnumValue.kt
+++ b/src/main/kotlin/com/psr/psr/global/resolver/EnumValue.kt
@@ -1,0 +1,7 @@
+package com.psr.psr.global.resolver
+
+class EnumValue(
+    val value: String
+) {
+    constructor(enumType: EnumType) : this(enumType.value)
+}

--- a/src/main/kotlin/com/psr/psr/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/psr/psr/product/controller/ProductController.kt
@@ -1,12 +1,15 @@
 package com.psr.psr.product.controller
 
 import com.psr.psr.global.dto.BaseResponse
+import com.psr.psr.global.entity.ReportCategory
 import com.psr.psr.global.jwt.UserAccount
+import com.psr.psr.product.dto.request.ReportProductReq
 import com.psr.psr.product.dto.response.GetProductDetailRes
 import com.psr.psr.product.dto.response.GetProductsByUserRes
 import com.psr.psr.product.dto.response.GetProductsRes
 import com.psr.psr.product.dto.response.MyProduct
 import com.psr.psr.product.service.ProductService
+import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -54,5 +57,15 @@ class ProductController(
                 return BaseResponse(productService.getProductsByUser(userId))
         }
 
+        /**
+         * 상품 신고
+         */
+        @PostMapping("/products/{productId}/report")
+        fun reportProduct(@AuthenticationPrincipal userAccount: UserAccount,
+                          @PathVariable productId: Long,
+                          @RequestBody @Valid request: ReportProductReq): BaseResponse<Unit> {
+                val category = ReportCategory.findByValue(request.category)
+                return BaseResponse(productService.reportProduct(userAccount.getUser(), productId, category))
+        }
 
 }

--- a/src/main/kotlin/com/psr/psr/product/dto/assembler/ProductAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/product/dto/assembler/ProductAssembler.kt
@@ -1,10 +1,12 @@
 package com.psr.psr.product.dto.assembler
 
+import com.psr.psr.global.entity.ReportCategory
 import com.psr.psr.product.dto.response.GetProductDetailRes
 import com.psr.psr.product.dto.response.GetProductsByUserRes
 import com.psr.psr.product.dto.response.MyProduct
 import com.psr.psr.product.entity.Product
 import com.psr.psr.product.entity.ProductImg
+import com.psr.psr.product.entity.ProductReport
 import com.psr.psr.user.entity.User
 import org.springframework.stereotype.Component
 
@@ -43,6 +45,14 @@ class ProductAssembler {
             isLike = isLike
         )
 
+    }
+
+    fun toReportEntity(product: Product, user: User, category: ReportCategory): ProductReport {
+        return ProductReport(
+            product = product,
+            user = user,
+            category = category
+        )
     }
 
 

--- a/src/main/kotlin/com/psr/psr/product/dto/request/ReportProductReq.kt
+++ b/src/main/kotlin/com/psr/psr/product/dto/request/ReportProductReq.kt
@@ -1,0 +1,11 @@
+package com.psr.psr.product.dto.request
+
+import com.psr.psr.global.entity.ReportCategory
+import com.psr.psr.global.resolver.EnumValid
+
+data class ReportProductReq(
+
+    @EnumValid(enumClass = ReportCategory::class, message = "올바르지 않은 신고 카테고리입니다.")
+    val category: String
+
+)

--- a/src/main/kotlin/com/psr/psr/product/entity/ProductReport.kt
+++ b/src/main/kotlin/com/psr/psr/product/entity/ProductReport.kt
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull
 @Entity
 data class ProductReport(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-        var id: Long,
+        var id: Long? = null,
 
     @ManyToOne
         @JoinColumn(nullable = false, name = "product_id")

--- a/src/main/kotlin/com/psr/psr/product/repository/ProductReportRepository.kt
+++ b/src/main/kotlin/com/psr/psr/product/repository/ProductReportRepository.kt
@@ -1,9 +1,12 @@
 package com.psr.psr.product.repository
 
+import com.psr.psr.product.entity.Product
 import com.psr.psr.product.entity.ProductReport
+import com.psr.psr.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ProductReportRepository: JpaRepository<ProductReport, Long> {
+    fun findByProductAndUserAndStatus(product: Product, user: User, activeStatus: String): ProductReport?
 }

--- a/src/main/kotlin/com/psr/psr/product/service/ProductService.kt
+++ b/src/main/kotlin/com/psr/psr/product/service/ProductService.kt
@@ -24,6 +24,7 @@ class ProductService(
     private val userInterestRepository: UserInterestRepository,
     private val productImgRepository: ProductImgRepository,
     private val productLikeRepository: ProductLikeRepository,
+    private val productReportRepository: ProductReportRepository,
     private val userRepository: UserRepository,
     private val productAssembler: ProductAssembler
 ) {

--- a/src/main/kotlin/com/psr/psr/product/service/ProductService.kt
+++ b/src/main/kotlin/com/psr/psr/product/service/ProductService.kt
@@ -1,6 +1,7 @@
 package com.psr.psr.product.service
 
 import com.psr.psr.global.Constant.UserStatus.UserStatus.ACTIVE_STATUS
+import com.psr.psr.global.entity.ReportCategory
 import com.psr.psr.global.exception.BaseException
 import com.psr.psr.global.exception.BaseResponseCode
 import com.psr.psr.product.dto.assembler.ProductAssembler
@@ -11,6 +12,7 @@ import com.psr.psr.product.dto.response.MyProduct
 import com.psr.psr.product.entity.Product
 import com.psr.psr.product.repository.ProductImgRepository
 import com.psr.psr.product.repository.ProductLikeRepository
+import com.psr.psr.product.repository.ProductReportRepository
 import com.psr.psr.product.repository.ProductRepository
 import com.psr.psr.user.entity.Category
 import com.psr.psr.user.entity.User
@@ -25,6 +27,7 @@ class ProductService(
     private val userInterestRepository: UserInterestRepository,
     private val productImgRepository: ProductImgRepository,
     private val productLikeRepository: ProductLikeRepository,
+    private val productReportRepository: ProductReportRepository,
     private val userRepository: UserRepository,
     private val productAssembler: ProductAssembler
 ) {
@@ -72,6 +75,15 @@ class ProductService(
         val isLike = productLikeRepository.existsByProductAndUserAndStatus(product, user, ACTIVE_STATUS)
 
         return productAssembler.toGetProductDetailResDto(isOwner, product, imgList, numOfLikes, isLike)
+    }
+
+    fun reportProduct(user: User, productId: Long, category: ReportCategory) {
+        val product: Product = productRepository.findByIdAndStatus(productId, ACTIVE_STATUS)
+            ?: throw BaseException(BaseResponseCode.NOT_FOUND_PRODUCT)
+        if (productReportRepository.findByProductAndUserAndStatus(product, user, ACTIVE_STATUS) != null)
+            throw BaseException(BaseResponseCode.REPORT_ALREADY_COMPLETE)
+
+        productReportRepository.save(productAssembler.toReportEntity(product, user, category))
     }
 
 }


### PR DESCRIPTION
## 🌱 이슈 번호
close #97

<br>

## 💬 기타 사항
- Enum 검증을 위한 @enumValid 어노테이션을 추가했습니다! 8b2811a2690a03a1604b401049f5f917392e4b0a
- 사용하는 방법
1. 검증할 enum에 EnumType 인터페이스 상속 8ffcdfb8fefba3b9e87c44d0ff69850f59cadecc
2. 검증하고자 하는 컬럼에 다음처럼 어노테이션 추가해 사용 (enum의 value값을 바탕으로 검증하도록 했습니다!)

| 이름 | 설명 |
|--------|--------|
| enumClass | 검증할 enumClass |
| message | 오류 메세지 | 

`@EnumValid(enumClass = ReportCategory::class, message = "올바르지 않은 신고 카테고리입니다.")`
`val category: String`