### PR TITLE
[feat] 관심 목록 조회 API

### DIFF
--- a/src/main/kotlin/com/psr/psr/cs/controller/CsController.kt
+++ b/src/main/kotlin/com/psr/psr/cs/controller/CsController.kt
@@ -17,7 +17,6 @@ class CsController(
          * 공지사항 메인
          */
         @GetMapping("/notices")
-        @ResponseBody
         fun getNotices(): BaseResponse<NoticeListRes>{
                 return BaseResponse(csService.getNotices())
         }
@@ -26,7 +25,6 @@ class CsController(
          * 공지사항 상세
          */
         @GetMapping("/notices/{noticeId}")
-        @ResponseBody
         fun getNotice(@PathVariable(name = "noticeId") noticeId: Long): BaseResponse<NoticeRes>{
                 return BaseResponse(csService.getNotice(noticeId))
         }
@@ -35,7 +33,6 @@ class CsController(
          * 자주 묻는 질문 메인
          */
         @GetMapping("/faqs")
-        @ResponseBody
         fun getFaqs(@RequestParam(value = "type", required = false) type: String?): BaseResponse<FaqListRes>{
                 return BaseResponse(csService.getFaqs(type))
         }
@@ -44,7 +41,6 @@ class CsController(
          * 자주 묻는 질문 상세
          */
         @GetMapping("/faqs/{faqId}")
-        @ResponseBody
         fun getFaq(@PathVariable(name = "faqId") faqId: Long): BaseResponse<FaqRes>{
                 return BaseResponse(csService.getFaq(faqId))
         }

--- a/src/main/kotlin/com/psr/psr/global/config/OpenEntityManagerConfig.kt
+++ b/src/main/kotlin/com/psr/psr/global/config/OpenEntityManagerConfig.kt
@@ -1,0 +1,18 @@
+package com.psr.psr.global.config
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewFilter
+
+
+@Configuration
+class OpenEntityManagerConfig {
+    @Bean
+    fun openEntityManagerInViewFilter(): FilterRegistrationBean<OpenEntityManagerInViewFilter>? {
+        val filterFilterRegistrationBean = FilterRegistrationBean<OpenEntityManagerInViewFilter>()
+        filterFilterRegistrationBean.filter = OpenEntityManagerInViewFilter()
+        filterFilterRegistrationBean.order = Int.MIN_VALUE
+        return filterFilterRegistrationBean
+    }
+}

--- a/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
+++ b/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
@@ -145,9 +145,18 @@ class UserController(
          */
         @PatchMapping("/watchlists")
         @ResponseBody
-        fun patchWatchLists(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated userInterestListReq: UserInterestListReq) : BaseResponse<Any>{
+        fun patchWatchLists(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated userInterestListReq: UserInterestListDto) : BaseResponse<Any>{
                 userService.patchWatchLists(userAccount.getUser(), userInterestListReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
+        }
+
+        /**
+         * 관심 목록 조회
+         */
+        @GetMapping("/watchlists")
+        @ResponseBody
+        fun getWatchList(@AuthenticationPrincipal userAccount: UserAccount) : BaseResponse<UserInterestListDto>{
+                return BaseResponse(userService.getWatchList(userAccount.getUser()))
         }
 
         /**

--- a/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
+++ b/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
@@ -131,7 +131,7 @@ class UserController(
         /**
          * 관심 목록 변경
          */
-        @PatchMapping("/watchlists")
+        @PatchMapping("/watchlist")
         fun patchWatchLists(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated userInterestListReq: UserInterestListDto) : BaseResponse<Any>{
                 userService.patchWatchLists(userAccount.getUser(), userInterestListReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -140,7 +140,7 @@ class UserController(
         /**
          * 관심 목록 조회
          */
-        @GetMapping("/watchlists")
+        @GetMapping("/watchlist")
         fun getWatchList(@AuthenticationPrincipal userAccount: UserAccount) : BaseResponse<UserInterestListDto>{
                 return BaseResponse(userService.getWatchList(userAccount.getUser()))
         }

--- a/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
+++ b/src/main/kotlin/com/psr/psr/user/controller/UserController.kt
@@ -28,7 +28,6 @@ class UserController(
          * 회원가입
          */
         @PostMapping("/signup")
-        @ResponseBody
         fun signUp (@RequestBody @Validated signUpReq: SignUpReq) : BaseResponse<TokenDto>{
                return BaseResponse(userService.signUp(signUpReq))
         }
@@ -37,7 +36,6 @@ class UserController(
          * 로그인
          */
         @PostMapping("/login")
-        @ResponseBody
         fun login (@RequestBody @Validated loginReq: LoginReq) : BaseResponse<TokenDto>{
                 return BaseResponse(userService.login(loginReq))
         }
@@ -46,7 +44,6 @@ class UserController(
          * 닉네임 중복
          */
         @PostMapping("/nickname")
-        @ResponseBody
         fun checkDuplicateNickname (@RequestBody @Validated nicknameReq: CheckNicknameReq) : BaseResponse<Boolean>{
                 // 사용 가능 : True, 사용 불가 : False
                 return BaseResponse(!userService.checkDuplicateNickname(nicknameReq.nickname))
@@ -56,7 +53,6 @@ class UserController(
          * 사용자 프로필 불러오기
          */
         @GetMapping("/profile")
-        @ResponseBody
         fun getProfile(@AuthenticationPrincipal userAccount: UserAccount) : BaseResponse<ProfileRes>{
                 return BaseResponse(userService.getProfile(userAccount.getUser()))
         }
@@ -65,7 +61,6 @@ class UserController(
          * 사용자 프로필 변경하기
          */
         @PostMapping("/profile")
-        @ResponseBody
         fun postProfile(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated profileReq: ProfileReq) : BaseResponse<Any> {
                 userService.postProfile(userAccount.getUser(), profileReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -75,7 +70,6 @@ class UserController(
          * 로그아웃
          */
         @PatchMapping("/logout")
-        @ResponseBody
         fun logout(@AuthenticationPrincipal userAccount: UserAccount, request: HttpServletRequest) : BaseResponse<Any> {
                 userService.blackListToken(userAccount.getUser(), request, LOGOUT)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -85,7 +79,6 @@ class UserController(
          * 회원 탈퇴
          */
         @DeleteMapping("/signout")
-        @ResponseBody
         fun signOut(@AuthenticationPrincipal userAccount: UserAccount, request: HttpServletRequest) : BaseResponse<Any> {
                 userService.blackListToken(userAccount.getUser(), request, INACTIVE_STATUS)
                 userService.signOut(userAccount.getUser())
@@ -96,7 +89,6 @@ class UserController(
          * 사업자 등록 번호 인증
          */
         @PostMapping("/eid")
-        @ResponseBody
         fun validateEid(@RequestBody @Validated userEidReq: UserEidReq) : BaseResponse<Boolean> {
                 userService.validateEid(userEidReq)
                 return BaseResponse(true)
@@ -106,7 +98,6 @@ class UserController(
          * 마이페이지 내 정보 화면
          */
         @GetMapping("/mypage")
-        @ResponseBody
         fun getMyPageInfo(@AuthenticationPrincipal userAccount: UserAccount) : BaseResponse<MyPageInfoRes>{
                return BaseResponse(userService.getMyPageInfo(userAccount.getUser()))
         }
@@ -115,7 +106,6 @@ class UserController(
          * 토큰 재발급
          */
         @PostMapping("/reissue")
-        @ResponseBody
         fun reissueToken(@RequestBody @Validated tokenDto: TokenDto) : BaseResponse<TokenDto>{
                 return BaseResponse(userService.reissueToken(tokenDto))
         }
@@ -124,7 +114,6 @@ class UserController(
          * 비밀번호 변경화면 with Token
          */
         @PatchMapping("/password-change")
-        @ResponseBody
         fun changePassword(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated passwordReq: ChangePasswordReq) : BaseResponse<Any>{
                 userService.changePassword(userAccount.getUser(), passwordReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -134,7 +123,6 @@ class UserController(
          * 비밀번호 재설정 except Token
          */
         @PatchMapping("/password-reset")
-        @ResponseBody
         fun resetPassword(@RequestBody @Validated resetPasswordReq: ResetPasswordReq) : BaseResponse<Any>{
                 userService.resetPassword(resetPasswordReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -144,7 +132,6 @@ class UserController(
          * 관심 목록 변경
          */
         @PatchMapping("/watchlists")
-        @ResponseBody
         fun patchWatchLists(@AuthenticationPrincipal userAccount: UserAccount, @RequestBody @Validated userInterestListReq: UserInterestListDto) : BaseResponse<Any>{
                 userService.patchWatchLists(userAccount.getUser(), userInterestListReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -154,7 +141,6 @@ class UserController(
          * 관심 목록 조회
          */
         @GetMapping("/watchlists")
-        @ResponseBody
         fun getWatchList(@AuthenticationPrincipal userAccount: UserAccount) : BaseResponse<UserInterestListDto>{
                 return BaseResponse(userService.getWatchList(userAccount.getUser()))
         }
@@ -163,7 +149,6 @@ class UserController(
          * 휴대폰번호 유효
          */
         @PostMapping("/phone/check")
-        @ResponseBody
         fun checkValidPhone(@RequestBody @Validated validPhoneReq: ValidPhoneReq) : BaseResponse<Any>{
                 userService.checkValidPhone(validPhoneReq)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -173,7 +158,6 @@ class UserController(
          * 휴대폰 인증번호 조회
          */
         @PostMapping("/phone/validation")
-        @ResponseBody
         fun checkValidSmsKey(@RequestBody @Validated validPhoneReq: ValidPhoneReq) : BaseResponse<Any>{
                 userService.checkValidSmsKey(validPhoneReq.phone, validPhoneReq.smsKey!!)
                 return BaseResponse(BaseResponseCode.SUCCESS)
@@ -183,7 +167,6 @@ class UserController(
          * 아이디 + 인증번호 조회
          */
         @PostMapping("/email/search")
-        @ResponseBody
         fun findEmailSearch(@RequestBody @Validated findIdPwReq: FindIdPwReq): BaseResponse<EmailRes>{
                 if(!StringUtils.hasText(findIdPwReq.name)) throw BaseException(BaseResponseCode.NOT_EMPTY_NAME)
                 return BaseResponse(userService.findEmailSearch(findIdPwReq))
@@ -193,7 +176,6 @@ class UserController(
          * 비밀번호 변경 + 인증번호 조회
          */
         @PostMapping("/password")
-        @ResponseBody
         fun findPWSearch(@RequestBody @Validated findIdPwReq: FindIdPwReq): BaseResponse<Any>{
                 if(!StringUtils.hasText(findIdPwReq.email)) throw BaseException(BaseResponseCode.NOT_EMPTY_EMAIL)
                 userService.findPWSearch(findIdPwReq)

--- a/src/main/kotlin/com/psr/psr/user/dto/UserInterestDto.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/UserInterestDto.kt
@@ -1,8 +1,8 @@
-package com.psr.psr.user.dto.request
+package com.psr.psr.user.dto
 
 import com.psr.psr.user.entity.Category
 
-data class UserInterestReq (
+data class UserInterestDto (
     val category: String
 ){
     fun checkInterestCategory() : Category{

--- a/src/main/kotlin/com/psr/psr/user/dto/UserInterestListDto.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/UserInterestListDto.kt
@@ -1,0 +1,5 @@
+package com.psr.psr.user.dto
+
+data class UserInterestListDto (
+    val interestList: List<UserInterestDto>?
+)

--- a/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
@@ -76,7 +76,7 @@ class UserAssembler {
     }
 
     fun toProfileRes(user: User) : ProfileRes {
-        return ProfileRes(user.email, user.imgUrl)
+        return ProfileRes(user.nickname, user.imgUrl)
     }
 
     fun toTokenDto(tokenDto: TokenDto) {

--- a/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
@@ -2,8 +2,8 @@ package com.psr.psr.user.dto.assembler
 
 import com.psr.psr.global.Constant
 import com.psr.psr.global.jwt.dto.TokenDto
-import com.psr.psr.user.dto.response.MyPageInfoRes
-import com.psr.psr.user.dto.response.ProfileRes
+import com.psr.psr.user.dto.UserInterestDto
+import com.psr.psr.user.dto.UserInterestListDto
 import com.psr.psr.user.dto.eidReq.Business
 import com.psr.psr.user.dto.eidReq.BusinessListReq
 import com.psr.psr.user.dto.phoneReq.MessageReq
@@ -12,6 +12,8 @@ import com.psr.psr.user.dto.request.SignUpReq
 import com.psr.psr.user.dto.request.UserEidReq
 import com.psr.psr.user.dto.request.ValidPhoneReq
 import com.psr.psr.user.dto.response.EmailRes
+import com.psr.psr.user.dto.response.MyPageInfoRes
+import com.psr.psr.user.dto.response.ProfileRes
 import com.psr.psr.user.entity.*
 import org.apache.commons.lang3.RandomStringUtils
 import org.springframework.stereotype.Component
@@ -93,6 +95,12 @@ class UserAssembler {
 
     fun toEmailResDto(user: User): EmailRes {
         return EmailRes(email = user.email)
+    }
+
+    fun toUserInterestListDto(interests: List<UserInterest>?): UserInterestListDto {
+        return UserInterestListDto(
+            interestList = interests?.map { i -> UserInterestDto(i.category.value) }?.toList()
+        )
     }
 
     /**

--- a/src/main/kotlin/com/psr/psr/user/dto/request/SignUpReq.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/request/SignUpReq.kt
@@ -1,5 +1,6 @@
 package com.psr.psr.user.dto.request
 
+import com.psr.psr.user.dto.UserInterestDto
 import jakarta.annotation.Nullable
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
@@ -39,6 +40,6 @@ data class SignUpReq (
     @field:NotNull
     val notification: Boolean,
     @field:NotEmpty
-    val interestList: List<UserInterestReq>,
+    val interestList: List<UserInterestDto>,
     val entreInfo: UserEidReq?= null
     )

--- a/src/main/kotlin/com/psr/psr/user/dto/request/UserInterestListReq.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/request/UserInterestListReq.kt
@@ -1,5 +1,0 @@
-package com.psr.psr.user.dto.request
-
-data class UserInterestListReq (
-    val interestList: List<UserInterestReq>
-)

--- a/src/main/kotlin/com/psr/psr/user/dto/response/ProfileRes.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/response/ProfileRes.kt
@@ -2,6 +2,6 @@ package com.psr.psr.user.dto.response
 
 
 data class ProfileRes(
-    val email: String,
+    val nickname: String,
     val imgUrl: String? = null
 )

--- a/src/main/kotlin/com/psr/psr/user/entity/User.kt
+++ b/src/main/kotlin/com/psr/psr/user/entity/User.kt
@@ -53,6 +53,10 @@ class User(
 
         @OneToMany(mappedBy = "user")
         @Where(clause = "status = 'active'")
-        var products: List<Product>? = null
+        var products: List<Product>? = null,
+
+        @OneToMany(mappedBy = "user")
+        @Where(clause = "status = 'active'")
+        var interests: List<UserInterest>? = null
 
 ): BaseEntity()

--- a/src/main/kotlin/com/psr/psr/user/entity/UserInterest.kt
+++ b/src/main/kotlin/com/psr/psr/user/entity/UserInterest.kt
@@ -9,7 +9,7 @@ data class UserInterest(
         @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
         var id: Long? = null,
 
-        @ManyToOne(fetch = FetchType.LAZY)
+        @ManyToOne
         @JoinColumn(nullable = false, name = "user_id")
         var user: User,
 

--- a/src/main/kotlin/com/psr/psr/user/entity/UserInterest.kt
+++ b/src/main/kotlin/com/psr/psr/user/entity/UserInterest.kt
@@ -9,7 +9,7 @@ data class UserInterest(
         @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
         var id: Long? = null,
 
-        @ManyToOne
+        @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(nullable = false, name = "user_id")
         var user: User,
 

--- a/src/main/kotlin/com/psr/psr/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/psr/psr/user/repository/UserRepository.kt
@@ -9,7 +9,6 @@ import java.util.*
 
 @Repository
 interface UserRepository: JpaRepository<User, Long> {
-    @EntityGraph(attributePaths = ["interests"])
     fun findByIdAndStatus(id: Long, status: String) : User?
     fun existsByNickname(nickname: String): Boolean
     fun existsByPhone(phone: String): Boolean

--- a/src/main/kotlin/com/psr/psr/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/psr/psr/user/repository/UserRepository.kt
@@ -2,12 +2,14 @@ package com.psr.psr.user.repository
 
 import com.psr.psr.user.entity.Type
 import com.psr.psr.user.entity.User
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
 interface UserRepository: JpaRepository<User, Long> {
+    @EntityGraph(attributePaths = ["interests"])
     fun findByIdAndStatus(id: Long, status: String) : User?
     fun existsByNickname(nickname: String): Boolean
     fun existsByPhone(phone: String): Boolean

--- a/src/main/kotlin/com/psr/psr/user/service/UserService.kt
+++ b/src/main/kotlin/com/psr/psr/user/service/UserService.kt
@@ -17,7 +17,6 @@ import com.psr.psr.global.Constant.UserPhone.UserPhone.TIMESTAMP_HEADER
 import com.psr.psr.global.Constant.UserPhone.UserPhone.UTF_8
 import com.psr.psr.global.Constant.UserStatus.UserStatus.ACTIVE_STATUS
 import com.psr.psr.global.exception.BaseException
-import com.psr.psr.global.exception.BaseResponseCode
 import com.psr.psr.global.exception.BaseResponseCode.*
 import com.psr.psr.global.jwt.dto.TokenDto
 import com.psr.psr.global.jwt.utils.JwtUtils
@@ -237,8 +236,8 @@ class UserService(
 
     // 관심 목록 변경
     @Transactional
-    fun patchWatchLists(user: User,  userInterestListReq: UserInterestListReq) {
-        val reqLists = userInterestListReq.interestList.map { i -> Category.getCategoryByName(i.category) }
+    fun patchWatchLists(user: User,  userInterestListReq: UserInterestListDto) {
+        val reqLists = userInterestListReq.interestList!!.map { i -> Category.getCategoryByName(i.category) }
         if(reqLists.isEmpty() || reqLists.size > 3) throw BaseException(INVALID_USER_INTEREST_COUNT)
         val userWatchLists = userInterestRepository.findByUserAndStatus(user, ACTIVE_STATUS)
         val categoryLists = userWatchLists.map { c -> c.category }
@@ -260,6 +259,11 @@ class UserService(
                 // todo: cascade 적용 후 모두 삭제 되었는지 확인 필요
                 if(!reqLists.contains(interest.category)) userInterestRepository.delete(interest)
             }
+    }
+
+    // 관심 목록 조회
+    fun getWatchList(user: User) :UserInterestListDto {
+        return userAssembler.toUserInterestListDto(user.interests)
     }
 
     // 유효 휴대폰 검증
@@ -330,8 +334,4 @@ class UserService(
         val rawHmac = mac.doFinal(message.toByteArray(charset(UTF_8)))
         return Base64.encodeBase64String(rawHmac)
     }
-
-
-
-
 }


### PR DESCRIPTION
## 🌱 이슈 번호
close #114 

<br>

## 💬 기타 사항
- Security 적용을 하면서 [다음과 같은 문제](https://velog.io/@davidko/LazyInitializationException-%EC%98%A4%EB%A5%98-%ED%95%B4%EA%B2%B0)로 인해서 userAccount에 저장된 User 내 oneToMany 객체에 접근시 LazyInitializationException에러가 났더라구요.,,!
- ~~현재 사용자 관심 목록은 Token 유효성 검사를 위한 User 조회 시, 한번에 같이 조회를 하는데 너무 비효율적인 것 같으면 삭제하구 Query로 처리하겠슴니다,,! (저는 비효율적이라고 생각이 들긴해용,,!)~~ -> 아래 해결법 적어뒀슴니당

## 😵‍💫 해결 방법
- Spring Security는 UserDetailsServiceImpl에서 Token에 저장된 User 객체를 불러오는데, 이 때 User의 영속성을 유지시키지 않고 준영속성으로 변경시켜버린대요 ! 그래서 Lazy로 불러오게 되면 에러가 난다구 하네용,,! 
- (단, 토큰에서 받아온 객체 말고, 그 후에 진행한 JPA Query에서 받아온 지연로딩 객체는 제외)
- 마지막 커밋과 같이 영속성 관련 필터를 가장 앞순위로 위치 시키면 Token에서 받아온 User는 영속성이 유지된다구 합니당
- 진자 어려운 Spring Security 의 세계,,, [출처1](https://tecoble.techcourse.co.kr/post/2020-08-31-entity-lifecycle-1/)  [출처2](https://tecoble.techcourse.co.kr/post/2020-09-20-entity-lifecycle-2/)
