### PR TITLE
[fix] 요청 목록 조회 res 변경

### DIFF
--- a/src/main/kotlin/com/psr/psr/order/dto/OrderAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/order/dto/OrderAssembler.kt
@@ -35,28 +35,6 @@ class OrderAssembler {
         )
     }
 
-    // 요청 목록 조회 시
-    fun toListDto(order: Order, type: String, productImgUrl: String): OrderListRes {
-        val userName =
-            if (type == SELL) order.ordererName
-            else order.product.user.nickname
-        val profileImg: String? =
-            if (type == SELL) order.user.imgUrl
-            else order.product.user.imgUrl
-
-        return OrderListRes(
-            orderId = order.id!!,
-            orderDate = order.createdAt.format(DateTimeFormatter.ISO_DATE),
-            userName = userName,
-            profileImgUrl = profileImg,
-            productId = order.product.id!!,
-            productName = order.product.name,
-            productImgUrl = productImgUrl,
-            isReviewed = null
-        )
-    }
-
-    // 마이페이지 요청 목록 조회 시
     fun toListDto(order: Order, type: String): OrderListRes {
         val userName =
             if (type == SELL) order.ordererName
@@ -66,11 +44,10 @@ class OrderAssembler {
             orderId = order.id!!,
             orderDate = order.createdAt.format(DateTimeFormatter.ISO_DATE),
             userName = userName,
-            profileImgUrl = null,
             productId = order.product.id!!,
             productName = order.product.name,
-            productImgUrl = null,
-            isReviewed = order.isReviewed
+            productImgUrl = order.product.imgs?.get(0)?.imgUrl,
+            reviewId = order.review?.id
         )
     }
 }

--- a/src/main/kotlin/com/psr/psr/order/dto/OrderListRes.kt
+++ b/src/main/kotlin/com/psr/psr/order/dto/OrderListRes.kt
@@ -1,16 +1,11 @@
 package com.psr.psr.order.dto
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 data class OrderListRes (
     val orderId: Long,
     val orderDate: String,
     val userName: String,
-    val profileImgUrl: String?,
     val productId: Long,
     val productName: String,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     val productImgUrl: String?,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val isReviewed: Boolean?
+    val reviewId: Long?
 )

--- a/src/main/kotlin/com/psr/psr/order/entity/Order.kt
+++ b/src/main/kotlin/com/psr/psr/order/entity/Order.kt
@@ -3,6 +3,7 @@ package com.psr.psr.order.entity
 import com.psr.psr.global.entity.BaseEntity
 import com.psr.psr.order.dto.OrderReq
 import com.psr.psr.product.entity.Product
+import com.psr.psr.review.entity.Review
 import com.psr.psr.user.entity.User
 import jakarta.persistence.*
 import org.jetbrains.annotations.NotNull
@@ -37,8 +38,9 @@ data class Order(
     @NotNull
     var description: String,
 
-    @NotNull
-    var isReviewed: Boolean = false
+    @OneToOne
+    @JoinColumn(name = "review_id")
+    var review: Review? = null
 
 ) : BaseEntity() {
     fun editOrder(orderReq: OrderReq?, orderStatus: OrderStatus?) {
@@ -53,8 +55,8 @@ data class Order(
         }
     }
 
-    fun changeReviewStatus(): Order {
-        this.isReviewed = !this.isReviewed
+    fun setReview(review: Review?): Order {
+        this.review = review
         return this
     }
 }

--- a/src/main/kotlin/com/psr/psr/order/service/OrderService.kt
+++ b/src/main/kotlin/com/psr/psr/order/service/OrderService.kt
@@ -44,8 +44,7 @@ class OrderService(
                 orderRepository.findByProductUserAndStatus(user, ACTIVE_STATUS, pageable)
             else
                 orderRepository.findByUserAndStatus(user, ACTIVE_STATUS, pageable)
-        return orderList.map { order: Order -> order.product.imgs?.get(0)
-            ?.let { orderAssembler.toListDto(order, type, it.imgUrl) } }
+        return orderList.map { order: Order -> orderAssembler.toListDto(order, type) }
     }
 
     // 요청 목록 조회(요청 상태별)

--- a/src/main/kotlin/com/psr/psr/review/entity/Review.kt
+++ b/src/main/kotlin/com/psr/psr/review/entity/Review.kt
@@ -18,8 +18,7 @@ data class Review(
     @JoinColumn(nullable = false, name = "product_id")
     var product: Product,
 
-    @OneToOne
-    @JoinColumn(nullable = false, name = "order_id")
+    @OneToOne(mappedBy = "review")
     var order: Order,
 
     @NotNull


### PR DESCRIPTION
## 🌱 이슈 번호
close #105

<br>

## 💬 기타 사항
- orders 테이블에 review_id를 넣어봤는데 괜찮은가요?? OneToOne인데 각 테이블에 서로 있는 상태라서 뭔가 이상한것 같기도 한데... 이렇게 안하면 요청 목록 조회할 때 reviewId를 갖고오기 위해서 map으로 계속 쿼리를 보내야합니다ㅜ 좋은 방법 있으면 알려주세요🤗
- 요청 목록 조회인데 커밋 메세지에 실수로 리뷰 목록이라고 했어요...ㅎㅎ
