### PR TITLE
[fix] 토큰 재발급시, AccessToken에서 사용자 정보를 불러오지 못하는 에러 해결

### DIFF
--- a/src/main/kotlin/com/psr/psr/global/jwt/utils/JwtUtils.kt
+++ b/src/main/kotlin/com/psr/psr/global/jwt/utils/JwtUtils.kt
@@ -101,11 +101,15 @@ class JwtUtils(
     }
 
     private fun parseClaims(token: String): Claims {
-        return Jwts.parserBuilder()
-            .setSigningKey(key)
-            .build()
-            .parseClaimsJws(token)
-            .body
+        return try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .body
+        } catch (e: ExpiredJwtException){ // 토큰이 만료되더라도 사용자 정보를 불러올 수 있도록 예외처리
+            return e.claims
+        }
     }
 
     /**


### PR DESCRIPTION
## 🌱 이슈 번호
close #140 

<br>

## 💬 기타 사항
- Accesstoken을 1분으로 처리하면서 알게된 오류로 같은 이슈번호를 사용했습니다 !
- 다음과 같이 parseClaims으로 AccessToken이 만료되더라도 사용자 정보를 불러오도록 해야하는데 자바 자료를 참고하면서 변경하다보니, 만료된 정보는 불러오지 못하도록 설계를 해버렸네욤,,, ㅎㅅㅎ 
