### PR TITLE
[feat] 알림 세팅 및 요청 관련 알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application-secret.yaml
+firebase-service-key.json
 
 ### STS ###
 .apt_generated

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,10 @@ dependencies {
 
 	// random
 	implementation("org.apache.commons:commons-lang3:3.12.0")
+
+	// notification
+	implementation("com.google.firebase:firebase-admin:9.2.0")
+	implementation("com.squareup.okhttp3:okhttp:4.10.0")
 }
 
 

--- a/src/main/kotlin/com/psr/psr/global/Constant.kt
+++ b/src/main/kotlin/com/psr/psr/global/Constant.kt
@@ -58,4 +58,11 @@ class Constant {
             const val POPULAR = "인기순"
         }
     }
+
+    class NotiSentence{
+        companion object NotiSentence{
+            const val NEW_ORDER_SENTENCE = "님의 요청을 확인해주세요!"
+            const val TWO_MONTH_ORDER_SENTENCE = "님의 요청 상태를 확인해주세요!"
+        }
+    }
 }

--- a/src/main/kotlin/com/psr/psr/notification/dto/Data.kt
+++ b/src/main/kotlin/com/psr/psr/notification/dto/Data.kt
@@ -1,0 +1,6 @@
+package com.psr.psr.notification.dto
+
+data class Data(
+    val relatedId: Long,
+    val notiType: String
+)

--- a/src/main/kotlin/com/psr/psr/notification/dto/FcmMessage.kt
+++ b/src/main/kotlin/com/psr/psr/notification/dto/FcmMessage.kt
@@ -1,0 +1,6 @@
+package com.psr.psr.notification.dto
+
+data class FcmMessage (
+    val validate_only: Boolean,
+    val message: Message
+)

--- a/src/main/kotlin/com/psr/psr/notification/dto/Message.kt
+++ b/src/main/kotlin/com/psr/psr/notification/dto/Message.kt
@@ -1,0 +1,7 @@
+package com.psr.psr.notification.dto
+
+data class Message(
+    val notification: Notification,
+    val token: String,
+    val data: Data
+)

--- a/src/main/kotlin/com/psr/psr/notification/dto/NotiAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/notification/dto/NotiAssembler.kt
@@ -1,0 +1,48 @@
+package com.psr.psr.notification.dto
+
+import com.psr.psr.notification.entity.NotificationType
+import com.psr.psr.notification.entity.PushNotification
+import com.psr.psr.user.entity.User
+import org.springframework.stereotype.Component
+
+
+@Component
+class NotiAssembler {
+    fun toEntity(receiver: User, title: String, content: String, relatedId: Long, type: NotificationType): PushNotification {
+        return PushNotification(
+            user = receiver,
+            title = title,
+            content = content,
+            relatedId = relatedId,
+            type = type
+        )
+    }
+    fun toMessageDTO(targetToken: String, title: String, body: String, relatedId: Long, notiType: String): Message {
+        return Message(
+            notification = toNotificationDTO(title, body),
+            token = targetToken,
+            data = toDataDTO(relatedId, notiType)
+        )
+    }
+
+    fun toNotificationDTO(title: String, body: String): Notification {
+        return Notification(
+            title = title,
+            body = body
+        )
+    }
+
+    fun toDataDTO(relatedId: Long, notiType: String): Data {
+        return Data(
+            relatedId = relatedId,
+            notiType = notiType
+        )
+    }
+
+    fun makeMessage(targetToken: String, title: String, body: String, relatedId: Long, notiType: String): FcmMessage {
+        return FcmMessage(
+            validate_only = false,
+            message = toMessageDTO(targetToken, title, body, relatedId, notiType)
+        )
+    }
+}

--- a/src/main/kotlin/com/psr/psr/notification/dto/Notification.kt
+++ b/src/main/kotlin/com/psr/psr/notification/dto/Notification.kt
@@ -1,0 +1,6 @@
+package com.psr.psr.notification.dto
+
+data class Notification(
+    val title: String,
+    val body: String
+)

--- a/src/main/kotlin/com/psr/psr/notification/entity/NotificationType.kt
+++ b/src/main/kotlin/com/psr/psr/notification/entity/NotificationType.kt
@@ -1,0 +1,8 @@
+package com.psr.psr.notification.entity
+
+enum class NotificationType {
+    NEW_ORDER,
+    CHANGED_ORDER_STATUS,
+    TWO_MONTH_ORDER,
+    CHAT
+}

--- a/src/main/kotlin/com/psr/psr/notification/entity/PushNotification.kt
+++ b/src/main/kotlin/com/psr/psr/notification/entity/PushNotification.kt
@@ -6,9 +6,9 @@ import jakarta.persistence.*
 import org.jetbrains.annotations.NotNull
 
 @Entity
-data class Notification(
+data class PushNotification(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long,
+    var id: Long? = null,
 
     @ManyToOne
     @JoinColumn(nullable = false, name = "user_id")
@@ -19,6 +19,12 @@ data class Notification(
     var title: String,
 
     @NotNull
-    var content: String
+    var content: String,
+
+    // 알림의 주체인 요청, 채팅 등의 ID
+    var relatedId: Long,
+
+    @NotNull
+    var type: NotificationType
 
 ) : BaseEntity()

--- a/src/main/kotlin/com/psr/psr/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/psr/psr/notification/repository/NotificationRepository.kt
@@ -1,9 +1,9 @@
 package com.psr.psr.notification.repository
 
-import com.psr.psr.notification.entity.Notification
+import com.psr.psr.notification.entity.PushNotification
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface NotificationRepository: JpaRepository<Notification, Long>, NotificationCustom {
+interface NotificationRepository: JpaRepository<PushNotification, Long>, NotificationCustom {
 }

--- a/src/main/kotlin/com/psr/psr/notification/repository/NotificationRepositoryImpl.kt
+++ b/src/main/kotlin/com/psr/psr/notification/repository/NotificationRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.psr.psr.notification.repository
 
 import com.psr.psr.notification.dto.NotiList
 import com.psr.psr.notification.dto.NotificationListRes
-import com.psr.psr.notification.entity.QNotification.notification
+import com.psr.psr.notification.entity.QPushNotification.pushNotification
 import com.psr.psr.user.entity.User
 import com.querydsl.core.group.GroupBy.groupBy
 import com.querydsl.core.group.GroupBy.list
@@ -23,19 +23,19 @@ class NotificationRepositoryImpl(
     override fun findNotificationByUserGroupByDate(user: User, pageable: Pageable): Page<NotificationListRes> {
         val formattedDate: StringTemplate = Expressions.stringTemplate(
             "DATE_FORMAT({0}, {1})",
-            notification.createdAt,
+            pushNotification.createdAt,
             ConstantImpl.create("%Y-%m-%d")
         )
 
         val result = queryFactory
-            .selectFrom(notification)
-            .where(notification.user.eq(user))
-            .orderBy(notification.id.desc())
+            .selectFrom(pushNotification)
+            .where(pushNotification.user.eq(user))
+            .orderBy(pushNotification.id.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .transform(groupBy(formattedDate)
                 .list(Projections.constructor(NotificationListRes::class.java, formattedDate,
-                    list(Projections.constructor(NotiList::class.java, notification.title, notification.content)))))
+                    list(Projections.constructor(NotiList::class.java, pushNotification.title, pushNotification.content)))))
         return PageImpl(result, pageable, result.size.toLong())
     }
 

--- a/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
@@ -1,17 +1,53 @@
 package com.psr.psr.notification.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.auth.oauth2.GoogleCredentials
+import com.psr.psr.notification.dto.NotiAssembler
 import com.psr.psr.notification.dto.NotificationListRes
 import com.psr.psr.notification.repository.NotificationRepository
 import com.psr.psr.user.entity.User
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpHeaders
 import org.springframework.stereotype.Service
 
 @Service
 class NotificationService(
-        private val notificationRepository: NotificationRepository
+    private val notificationRepository: NotificationRepository,
+    private val notiAssembler: NotiAssembler,
+    @Value("\${firebase.sendUrl}") private val sendUrl: String,
+    private val objectMapper: ObjectMapper
 ) {
+    // 알림 목록 조회
     fun getNotiList(user: User, pageable: Pageable): Page<NotificationListRes> {
         return notificationRepository.findNotificationByUserGroupByDate(user, pageable)
+    }
+
+    // firebase accessToken 발급
+    private fun getAccessToken(): String? {
+        val firebaseConfigPath = "firebase-service-key.json"
+        val googleCredentials = GoogleCredentials
+            .fromStream(ClassPathResource(firebaseConfigPath).inputStream)
+            .createScoped(listOf("https://www.googleapis.com/auth/cloud-platform"))
+        googleCredentials.refreshIfExpired()
+        return googleCredentials.accessToken.tokenValue
+    }
+
+    // 메세지 전송
+    private fun sendMessage(message: String): Response {
+        val client = OkHttpClient()
+        val requestBody: RequestBody = message.toRequestBody("application/json; charset=utf-8".toMediaType())
+        val request: Request = Request.Builder()
+            .url(sendUrl)
+            .post(requestBody)
+            .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+            .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+            .build()
+        return client.newCall(request).execute()
     }
 }

--- a/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
@@ -44,7 +44,7 @@ class NotificationService(
             NotificationType.NEW_ORDER
         ))
 
-        if (orderReceiver.deviceToken != null) {
+        if (isPushNotiAvailable(orderReceiver)) {
             val message: FcmMessage = notiAssembler.makeMessage(
                 orderReceiver.deviceToken!!,
                 productName,
@@ -67,7 +67,7 @@ class NotificationService(
             NotificationType.CHANGED_ORDER_STATUS
         ))
 
-        if (orderer.deviceToken != null) {
+        if (isPushNotiAvailable(orderer)) {
             val message: FcmMessage = notiAssembler.makeMessage(
                 orderer.deviceToken!!,
                 productName,
@@ -90,7 +90,7 @@ class NotificationService(
             NotificationType.TWO_MONTH_ORDER
         ))
 
-        if (orderer.deviceToken != null) {
+        if (isPushNotiAvailable(orderer)) {
             val message: FcmMessage = notiAssembler.makeMessage(
                 orderer.deviceToken!!,
                 productName,
@@ -100,6 +100,11 @@ class NotificationService(
             )
             sendMessage(objectMapper.writeValueAsString(message))
         }
+    }
+
+    // 알림 수신 상태 체크
+    fun isPushNotiAvailable(user: User): Boolean {
+        return user.deviceToken != null && user.notification
     }
 
     // firebase accessToken 발급

--- a/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/psr/psr/notification/service/NotificationService.kt
@@ -2,9 +2,14 @@ package com.psr.psr.notification.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.auth.oauth2.GoogleCredentials
+import com.psr.psr.global.Constant.NotiSentence.NotiSentence.NEW_ORDER_SENTENCE
+import com.psr.psr.global.Constant.NotiSentence.NotiSentence.TWO_MONTH_ORDER_SENTENCE
+import com.psr.psr.notification.dto.FcmMessage
 import com.psr.psr.notification.dto.NotiAssembler
 import com.psr.psr.notification.dto.NotificationListRes
+import com.psr.psr.notification.entity.NotificationType
 import com.psr.psr.notification.repository.NotificationRepository
+import com.psr.psr.order.entity.OrderStatus
 import com.psr.psr.user.entity.User
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
@@ -26,6 +31,75 @@ class NotificationService(
     // 알림 목록 조회
     fun getNotiList(user: User, pageable: Pageable): Page<NotificationListRes> {
         return notificationRepository.findNotificationByUserGroupByDate(user, pageable)
+    }
+
+    // 새로운 요청 알림
+    fun sendNewOrderNoti(productName: String, orderReceiver: User, ordererName: String, orderId: Long) {
+        val messageBody = ordererName + NEW_ORDER_SENTENCE
+        notificationRepository.save(notiAssembler.toEntity(
+            orderReceiver,
+            productName,
+            messageBody,
+            orderId,
+            NotificationType.NEW_ORDER
+        ))
+
+        if (orderReceiver.deviceToken != null) {
+            val message: FcmMessage = notiAssembler.makeMessage(
+                orderReceiver.deviceToken!!,
+                productName,
+                messageBody,
+                orderId,
+                NotificationType.NEW_ORDER.name
+            )
+            sendMessage(objectMapper.writeValueAsString(message))
+        }
+    }
+
+    // 요청 상태 변경 알림
+    fun sendChangeOrderStatusNoti(productName: String, orderer: User, orderStatus: OrderStatus, orderId: Long) {
+        val messageBody = orderStatus.notiSentence!!
+        notificationRepository.save(notiAssembler.toEntity(
+            orderer,
+            productName,
+            messageBody,
+            orderId,
+            NotificationType.CHANGED_ORDER_STATUS
+        ))
+
+        if (orderer.deviceToken != null) {
+            val message: FcmMessage = notiAssembler.makeMessage(
+                orderer.deviceToken!!,
+                productName,
+                messageBody,
+                orderId,
+                NotificationType.CHANGED_ORDER_STATUS.name
+            )
+            sendMessage(objectMapper.writeValueAsString(message))
+        }
+    }
+
+    // 2달 뒤 요청상태 입력 요망 알림
+    fun send2MonthOrderNoti(productName: String, orderer: User, ordererName: String, orderId: Long) {
+        val messageBody = ordererName + TWO_MONTH_ORDER_SENTENCE
+        notificationRepository.save(notiAssembler.toEntity(
+            orderer,
+            productName,
+            messageBody,
+            orderId,
+            NotificationType.TWO_MONTH_ORDER
+        ))
+
+        if (orderer.deviceToken != null) {
+            val message: FcmMessage = notiAssembler.makeMessage(
+                orderer.deviceToken!!,
+                productName,
+                messageBody,
+                orderId,
+                NotificationType.TWO_MONTH_ORDER.name
+            )
+            sendMessage(objectMapper.writeValueAsString(message))
+        }
     }
 
     // firebase accessToken 발급

--- a/src/main/kotlin/com/psr/psr/order/dto/OrderAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/order/dto/OrderAssembler.kt
@@ -23,7 +23,7 @@ class OrderAssembler {
     fun toOrderResDTO(order: Order, isSeller: Boolean): OrderRes {
         return OrderRes(
             isSeller = isSeller,
-            status = order.orderStatus.statusName,
+            status = order.orderStatus.value,
             orderUserId = order.user.id!!,
             orderDate = order.createdAt.format(DateTimeFormatter.ISO_DATE),
             productId = order.product.id!!,

--- a/src/main/kotlin/com/psr/psr/order/entity/OrderStatus.kt
+++ b/src/main/kotlin/com/psr/psr/order/entity/OrderStatus.kt
@@ -2,16 +2,17 @@ package com.psr.psr.order.entity
 
 import com.psr.psr.global.exception.BaseException
 import com.psr.psr.global.exception.BaseResponseCode
+import com.psr.psr.global.resolver.EnumType
 
-enum class OrderStatus(val statusName: String) {
-    ORDER_WAITING("요청대기"),
-    PROGRESSING("진행중"),
-    COMPLETED("진행완료"),
-    CANCELED("요청취소");
+enum class OrderStatus(override val value: String, val notiSentence: String): EnumType {
+    ORDER_WAITING("요청대기", "님의 요청을 확인해주세요!"),
+    PROGRESSING("진행중", "요청이 진행되었습니다"),
+    COMPLETED("진행완료", "요청이 진행 완료되었습니다"),
+    CANCELED("요청취소", "요청이 취소되었습니다");
 
     companion object {
-        fun findByName(statusName: String): OrderStatus {
-            return OrderStatus.values().find { it.statusName == statusName }
+        fun findByValue(value: String): OrderStatus {
+            return enumValues<OrderStatus>().find { it.value == value }
                 ?: throw BaseException(BaseResponseCode.INVALID_ORDER_STATUS)
         }
     }

--- a/src/main/kotlin/com/psr/psr/order/entity/OrderStatus.kt
+++ b/src/main/kotlin/com/psr/psr/order/entity/OrderStatus.kt
@@ -4,8 +4,8 @@ import com.psr.psr.global.exception.BaseException
 import com.psr.psr.global.exception.BaseResponseCode
 import com.psr.psr.global.resolver.EnumType
 
-enum class OrderStatus(override val value: String, val notiSentence: String): EnumType {
-    ORDER_WAITING("요청대기", "님의 요청을 확인해주세요!"),
+enum class OrderStatus(override val value: String, val notiSentence: String?): EnumType {
+    ORDER_WAITING("요청대기", null),
     PROGRESSING("진행중", "요청이 진행되었습니다"),
     COMPLETED("진행완료", "요청이 진행 완료되었습니다"),
     CANCELED("요청취소", "요청이 취소되었습니다");

--- a/src/main/kotlin/com/psr/psr/order/service/OrderService.kt
+++ b/src/main/kotlin/com/psr/psr/order/service/OrderService.kt
@@ -49,7 +49,7 @@ class OrderService(
 
     // 요청 목록 조회(요청 상태별)
     fun getOrderListByOrderStatus(user: User, type: String, status: String, pageable: Pageable): Page<OrderListRes> {
-        val orderStatus = OrderStatus.findByName(status)
+        val orderStatus = OrderStatus.findByValue(status)
         val orderList: Page<Order> =
             if (type == SELL)
                 orderRepository.findByProductUserAndOrderStatusAndStatus(user, orderStatus, ACTIVE_STATUS, pageable)
@@ -65,7 +65,7 @@ class OrderService(
         if (order.user.id != user.id) throw BaseException(BaseResponseCode.NO_PERMISSION)
 
         var orderStatus: OrderStatus? = null
-        if (status != null) orderStatus = OrderStatus.findByName(status)
+        if (status != null) orderStatus = OrderStatus.findByValue(status)
 
         order.editOrder(orderReq, orderStatus)
         orderRepository.save(order)

--- a/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/assembler/UserAssembler.kt
@@ -37,7 +37,8 @@ class UserAssembler {
             marketing = signUpReq.marketing,
             notification = signUpReq.notification,
             name = signUpReq.name,
-            nickname = signUpReq.nickname)
+            nickname = signUpReq.nickname,
+            deviceToken = signUpReq.deviceToken)
     }
 
     fun toInterestListEntity(user: User, signUpReq: SignUpReq): List<UserInterest> {

--- a/src/main/kotlin/com/psr/psr/user/dto/request/SignUpReq.kt
+++ b/src/main/kotlin/com/psr/psr/user/dto/request/SignUpReq.kt
@@ -43,6 +43,7 @@ data class SignUpReq (
     val marketing: Boolean,
     @field:NotNull
     val notification: Boolean,
+    val deviceToken: String? = null,
     @field:NotEmpty
     val interestList: List<UserInterestDto>,
     val entreInfo: UserEidReq?= null

--- a/src/main/kotlin/com/psr/psr/user/entity/User.kt
+++ b/src/main/kotlin/com/psr/psr/user/entity/User.kt
@@ -55,6 +55,8 @@ class User(
         @NotNull
         var notification: Boolean,
 
+        var deviceToken: String? = null,
+
         @OneToMany(mappedBy = "user")
         @Where(clause = "status = 'active'")
         var products: List<Product>? = ArrayList(),


### PR DESCRIPTION
## 🌱 이슈 번호
close #139

<br>

## 💬 기타 사항
- 요청하기, 요청 상태 변경하기에는 적용시켜놨고, 2달 이후 알림은 나중에 스케줄러 사용할 예정입니다.
- 그리고 User 엔티티에 notification 컬럼이 필요한가요? 피그마 보면 알림 수신 여부 선택하는 건 없더라구여. 필요없는거면 지우겠습니당.
- 로그아웃을 한 사용자라도 나중에 로그인했을 때 그동안 온 알림도 볼 수 있게 일단 알림 목록에 저장하게 했습니당(알림을 보내진 않아요)
- 비밀 파일이 생겼으니 다들 추가해놓으세용
- 프론트랑 연결을 다음시간에....
